### PR TITLE
Fix slice copy in token reader

### DIFF
--- a/tokenbuf.go
+++ b/tokenbuf.go
@@ -29,6 +29,6 @@ func (r *bufTokenReader) Tokens() ([]token, error) {
 	}
 	subslice := r.tokens[r.i:]
 	ret := make([]token, len(subslice))
-	copy(subslice, ret)
+	copy(ret, subslice)
 	return ret, nil
 }


### PR DESCRIPTION
## Summary
- fix `Tokens()` in bufTokenReader to correctly copy tokens

## Testing
- `go test ./...` *(fails: unable to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_685dedb7a5f8832fbf8b2d593872df81